### PR TITLE
Added type: contao-module to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name":"bit3/contao-event-dispatcher",
 	"description":"Event dispatcher service for Contao Open Source CMS",
 	"keywords":["contao", "event"],
+	"type": "contao-module",
 	"license":"LGPL-3.0+",
 	"authors":[
 		{


### PR DESCRIPTION
This is needed for the Contao installer to kick in and create symlinks.
